### PR TITLE
Don't try to load associations for abstract base classes.

### DIFF
--- a/lib/schema_associations/active_record/associations.rb
+++ b/lib/schema_associations/active_record/associations.rb
@@ -80,6 +80,7 @@ module SchemaAssociations
       def _load_schema_associations_associations #:nodoc:
         return if @schema_associations_associations_loaded
         @schema_associations_associations_loaded = true
+        return if abstract_class?
         return unless schema_associations_config.auto_create?
 
         reverse_foreign_keys.each do | foreign_key |

--- a/spec/association_spec.rb
+++ b/spec/association_spec.rb
@@ -637,6 +637,27 @@ describe ActiveRecord::Base do
   end
 
 
+  context "with abstract base classes" do
+    before(:each) do
+      create_tables(
+        "posts", {}, {}
+      )
+      class PostBase < ActiveRecord::Base ; self.abstract_class = true ; end
+      class Post < PostBase ; end
+    end
+
+    it "should skip abstract classes" do
+      expect { PostBase.table_name }.to_not raise_error
+      expect( PostBase.table_name ).to be_nil
+      expect( !! PostBase.table_exists? ).to eq(false)
+    end
+
+    it "should work with classes derived from abstract classes" do
+      expect( Post.table_name ).to eq("posts")
+      expect( !! Post.table_exists? ).to eq(true)
+    end
+  end
+
   if defined? ::ActiveRecord::Relation
 
     context "regarding relations" do


### PR DESCRIPTION
This is a fix for Issue #12 

If a model class is an abstract base class, it uses `self.abstract_class = true`, then it has no real table backing it.  So do not attempt to query the database for schema information about the class.